### PR TITLE
Add support for an instance-local.yaml file in the backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2024-04-23
+
+- Add support for an instance-local.yaml file in the backend which is git ignored, so you can locally change storage for the backend. [fredvd]
+
 # 2024-03-08
 
 - Switch to plone.distribution. [pbauer]

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -41,3 +41,4 @@ live.cfg
 inituser
 pip-wheel-metadata
 pyvenv.cfg
+instance-local.yaml

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -96,7 +96,12 @@ bin/pip:
 .PHONY: config
 config: bin/pip  ## Create instance configuration
 	@echo "$(GREEN)==> Create instance configuration$(RESET)"
-	bin/cookiecutter -f --no-input --config-file instance.yaml gh:plone/cookiecutter-zope-instance
+	if [[ -s instance-override.yaml ]]; then \
+				echo "    Using instance-local.yaml"; \
+				bin/cookiecutter -f --no-input --config-file instance-local.yaml gh:plone/cookiecutter-zope-instance ;\
+	else \
+				bin/cookiecutter -f --no-input --config-file instance.yaml gh:plone/cookiecutter-zope-instance ;\
+	fi
 
 # i18n
 bin/i18ndude: bin/pip


### PR DESCRIPTION
which is  ignored, so you can locally change for example storage for the backend without  git conficts while developing. 

It basically works like the docker-compose.override.yaml, but the we don't merge the file contents, replace it. Hence 'local' and not 'override'. 