### PR TITLE
Update README: export content to distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2024-09-07
+
+- Update instructions. [ksuess]
+
 
 # 2024-05-17
 

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ install-classic:  ## Create virtualenv and install Plone
 build-classic:  ## Build classic
 	$(MAKE) -C "./classic/" build-dev
 
-.PHONY: export-distribution
+.PHONY: export-distribution-classic
 export-distribution-classic: ## Export content
 	$(MAKE) -C "./classic/" export-distribution
 

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ install-backend:  ## Create virtualenv and install Plone
 build-backend:  ## Build Backend
 	$(MAKE) -C "./backend/" build-dev
 
+.PHONY: export-distribution
+export-distribution: ## Export content
+	$(MAKE) -C "./backend/" export-distribution
+
 .PHONY: create-site
 create-site: ## Create a Plone site with default content
 	$(MAKE) -C "./backend/" create-site
@@ -127,6 +131,10 @@ install-classic:  ## Create virtualenv and install Plone
 .PHONY: build-classic
 build-classic:  ## Build classic
 	$(MAKE) -C "./classic/" build-dev
+
+.PHONY: export-distribution
+export-distribution-classic: ## Export content
+	$(MAKE) -C "./classic/" export-distribution
 
 .PHONY: create-site-classic
 create-site-classic: ## Create a Plone site with default content

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The demo-sites use https://github.com/plone/plone.distribution to create and man
 
 To update/extend the content run the site locally and make the changes you wish to see.
 
-Use http://localhost:8080/Plone/@@dist_export_all to export the data.
+Use `make export-distribution` and  `make export-distribution-classic` to export the data to the distribution.
 
 Test your changes by creating a fresh site:
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The demo-sites use https://github.com/plone/plone.distribution to create and man
 
 To update/extend the content run the site locally and make the changes you wish to see.
 
-Use `make export-distribution` and  `make export-distribution-classic` to export the data to the distribution.
+Use `make export-distribution` and `make export-distribution-classic` to export the data to the distribution.
 
 Test your changes by creating a fresh site:
 

--- a/README.md
+++ b/README.md
@@ -53,17 +53,31 @@ The demo-sites use https://github.com/plone/plone.distribution to create and man
 
 To update/extend the content run the site locally and make the changes you wish to see.
 
-Use `make export-distribution` and `make export-distribution-classic` to export the data to the distribution.
+Export and test depending on the type of site: Volto or Classic.
+
+#### Volto
+
+Export the data to the distribution:
+
+```shell
+make export-distribution
+```
 
 Test your changes by creating a fresh site:
-
-Volto:
 
 ```shell
 make create-site
 ```
 
-Classic:
+#### Classic
+
+Export the data to the distribution:
+
+```shell
+make export-distribution-classic
+```
+
+Test your changes by creating a fresh site:
 
 ```shell
 make create-site-classic

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -158,6 +158,10 @@ test: ## run tests
 test_quiet: ## run tests removing deprecation warnings
 	PYTHONWARNINGS=ignore ./bin/zope-testrunner --auto-color --auto-progress --test-path src/plone6demo/src/
 
+.PHONY: export-distribution
+export-distribution: ## Export content
+	bin/export-distribution instance/etc/zope.conf Plone
+
 .PHONY: create-site
 create-site: ## Create a new site using default distribution and default answers
 	DEVELOP_DISTRIBUTIONS=$(DISTRIBUTIONS) ALLOWED_DISTRIBUTIONS=$(DISTRIBUTIONS) PYTHONWARNINGS=ignore ./bin/zconsole run instance/etc/zope.conf scripts/create_site.py

--- a/classic/Makefile
+++ b/classic/Makefile
@@ -153,6 +153,10 @@ test: ## run tests
 test_quiet: ## run tests removing deprecation warnings
 	PYTHONWARNINGS=ignore ./bin/zope-testrunner --auto-color --auto-progress --test-path src/plonedemo.site/src/
 
+.PHONY: export-distribution
+export-distribution: ## Export content
+	bin/export-distribution instance/etc/zope.conf Plone
+
 .PHONY: create-site
 create-site: ## Create a new site using default distribution and default answers
 	DEVELOP_DISTRIBUTIONS=$(DISTRIBUTIONS) ALLOWED_DISTRIBUTIONS=$(DISTRIBUTIONS) PYTHONWARNINGS=ignore ./bin/zconsole run instance/etc/zope.conf scripts/create_site.py


### PR DESCRIPTION
Im digging into distributions and thought demo.plone.org would be a good starting point as it is in production.

I found out that the mentioned export view does not exist (anymore?).
I included the call of the plone.exportimport script in the Makefiles.