### PR TITLE
Add collective.honeypot to volto demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2025-06-25
+
+- Add collective.honeypot to Volto demo. @davisagli
+
 # 2025-06-16
 
 - Bring back the login `portal_action` in main Volto demo site. @sneridagh

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -55,7 +55,7 @@ setup(
         "plone.api",
         "plone.restapi",
         "plone.volto",
-        "collective.volto.formsupport",
+        "collective.volto.formsupport[honeypot]",
         "kitconcept.voltolighttheme",
     ],
     extras_require={

--- a/backend/src/plone6/demo/distributions/voltodemo/profiles.json
+++ b/backend/src/plone6/demo/distributions/voltodemo/profiles.json
@@ -4,6 +4,7 @@
     "plone.app.caching:default",
     "plonetheme.barceloneta:default",
     "collective.volto.formsupport:default",
+    "collective.honeypot:default",
     "plone.volto:default",
     "plone6.demo:default"
   ]


### PR DESCRIPTION
This is required in order to actually save a form block.